### PR TITLE
Extend the equality condition to match both xml_attrs and data. Fixes #16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,10 @@
 # All rights reserved.
 language: python
 python:
-  - "2.6"
   - "2.7"
-  - "3.2"
-  - "3.4"
   - "3.5"
+  - "3.7"
+  - "3.6"
   - "nightly"
   - "pypy"
   - "pypy3"

--- a/jxmlease/_basenode.py
+++ b/jxmlease/_basenode.py
@@ -691,7 +691,7 @@ class XMLNodeBase(object):
         try:
             made_change = False
             for i in range(0, len(self.parent)):
-                if self.parent[i] == self:
+                if self.parent[i] == self and self.parent[i].xml_attrs == self.xml_attrs:
                     if newnode is not None:
                         self.parent[i] = newnode
                         return


### PR DESCRIPTION
## Root cause
After encountering an `end-element`, the code proceeds to generate a new node of the current element that contains the stripped data of the current element.  Now, the current node has to be replaced with the new node. So, we loop through the parent node to replace it. 

The problem arises as we only compare the data. In the case of #16, when all elements contain the same data(no data) it matches the first element and proceeds to replace it.

## Fix info
Extended the equality condition to match both `data` and `xml_attrs`.
Fixes #16.

## Tests Added 
No

## Logs

__XML__
```
<api version="2">
    <row recordID="2340848521" typeID="2319" quantity="2165" singleton="0" included="1"/>
    <row recordID="2340848531" typeID="3691" quantity="2060" singleton="0" included="1"/>
</api>
```

__Results__
```
{
  'api': {
    'row': XMLListNode(xml_attrs = OrderedDict(), value = [
        XMLCDATANode(xml_attrs = OrderedDict([('recordID', '2340848521'), ('typeID', '2319'), ('quantity', '2165'), ('singleton', '0'), ('included', '1')]), value = ''), 
        XMLCDATANode(xml_attrs = OrderedDict([('recordID', '2340848531'), ('typeID', '3691'), ('quantity', '2060'), ('singleton', '0'), ('included', '1')]), value = '')])
  }
}
```